### PR TITLE
TypeScript Standalone 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
 		.library(name: "SwiftLexicon", targets: ["SwiftLexicon"]),
 		.library(name: "SwiftStandAlone", targets: ["SwiftStandAlone"]),
 		.library(name: "KotlinStandAlone", targets: ["KotlinStandAlone"]),
+        .library(name: "TypeScriptStandAlone", targets: ["TypeScriptStandAlone"]),
 		.library(name: "LexiconGenerators", targets: ["LexiconGenerators"]),
 	],
 	dependencies: [
@@ -49,7 +50,8 @@ let package = Package(
 					"Lexicon",
 					"SwiftLexicon",
 					"SwiftStandAlone",
-					"KotlinStandAlone"
+					"KotlinStandAlone",
+                    "TypeScriptStandAlone",
 				]
 			),
 		
@@ -109,5 +111,24 @@ let package = Package(
 				.copy("Resources"),
 			]
 		),
+        
+        // MARK: TypeScriptStandAlones
+        
+            .target(
+                name: "TypeScriptStandAlone",
+                dependencies: [
+                    "Lexicon",
+                ]
+            ),
+        .testTarget(
+            name: "TypeScriptStandAloneTests",
+            dependencies: [
+                "Hope",
+                "TypeScriptStandAlone"
+            ],
+            resources: [
+                .copy("Resources"),
+            ]
+        ),
 	]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
 		.library(name: "SwiftLexicon", targets: ["SwiftLexicon"]),
 		.library(name: "SwiftStandAlone", targets: ["SwiftStandAlone"]),
 		.library(name: "KotlinStandAlone", targets: ["KotlinStandAlone"]),
-        .library(name: "TypeScriptStandAlone", targets: ["TypeScriptStandAlone"]),
+		.library(name: "TypeScriptStandAlone", targets: ["TypeScriptStandAlone"]),
 		.library(name: "LexiconGenerators", targets: ["LexiconGenerators"]),
 	],
 	dependencies: [
@@ -51,7 +51,7 @@ let package = Package(
 					"SwiftLexicon",
 					"SwiftStandAlone",
 					"KotlinStandAlone",
-                    "TypeScriptStandAlone",
+					"TypeScriptStandAlone",
 				]
 			),
 		
@@ -111,24 +111,24 @@ let package = Package(
 				.copy("Resources"),
 			]
 		),
-        
-        // MARK: TypeScriptStandAlones
-        
-            .target(
-                name: "TypeScriptStandAlone",
-                dependencies: [
-                    "Lexicon",
-                ]
-            ),
-        .testTarget(
-            name: "TypeScriptStandAloneTests",
-            dependencies: [
-                "Hope",
-                "TypeScriptStandAlone"
-            ],
-            resources: [
-                .copy("Resources"),
-            ]
-        ),
+		
+		// MARK: TypeScriptStandAlones
+		
+			.target(
+				name: "TypeScriptStandAlone",
+				dependencies: [
+					"Lexicon",
+				]
+			),
+		.testTarget(
+			name: "TypeScriptStandAloneTests",
+			dependencies: [
+				"Hope",
+				"TypeScriptStandAlone"
+			],
+			resources: [
+				.copy("Resources"),
+			]
+		),
 	]
 )

--- a/Sources/LexiconGenerators/List.swift
+++ b/Sources/LexiconGenerators/List.swift
@@ -7,6 +7,7 @@ import Collections
 import SwiftLexicon
 import SwiftStandAlone
 import KotlinStandAlone
+import TypeScriptStandAlone
 
 public extension Lexicon.Graph.JSON {
 	
@@ -17,6 +18,8 @@ public extension Lexicon.Graph.JSON {
 		"Swift Stand-Alone": SwiftStandAlone.Generator.self,
 		
 		"Kotlin Stand-Alone": KotlinStandAlone.Generator.self,
+		
+		"TypeScript Stand-Alone": TypeScriptStandAlone.Generator.self,
 		
 		"JSON Classes & Mixins": JSONClasses.self,
 	]

--- a/Sources/TypeScriptStandAlone/Generator.swift
+++ b/Sources/TypeScriptStandAlone/Generator.swift
@@ -95,7 +95,6 @@ private extension Lexicon.Graph.Node.Class.JSON {
         // implements
         
         for t in type ?? [] {
-            print(t)
             let subClass = classes.filter{$0.id == t}.first
             for child in subClass?.children ?? [] {
                 let id = "L.\(t).\(child)"

--- a/Sources/TypeScriptStandAlone/Generator.swift
+++ b/Sources/TypeScriptStandAlone/Generator.swift
@@ -1,0 +1,144 @@
+//
+// github.com/screensailor 2022
+//
+
+import Lexicon
+import UniformTypeIdentifiers
+
+public enum Generator: CodeGenerator {
+    
+    // TODO: prefixes?
+    
+    public static let utType = UTType.sourceCode
+    
+    public static func generate(_ json: Lexicon.Graph.JSON) throws -> Data {
+        return Data(json.ts().utf8)
+    }
+}
+
+private extension Lexicon.Graph.JSON {
+    
+    func ts() -> String {
+        return """
+// I
+interface I extends TypeLocalized, SourceCodeIdentifiable { }
+interface TypeLocalized {
+    localized: string
+}
+interface SourceCodeIdentifiable {
+    identifier: string
+}
+// L
+class L implements I {
+    localized: string;
+    identifier: string;
+
+    constructor(id: string, localized = "") {
+        this.localized = localized;
+        this.identifier = id;
+    }
+}
+// MARK: generated types
+\(classes.flatMap{ $0.ts(prefix: ("L", "I"), classes: classes) }.joined(separator: "\n"))
+const \(name) = new L_\(name)("\(name)");
+
+"""
+    }
+}
+
+private extension Lexicon.Graph.Node.Class.JSON {
+    
+    // TODO: make this more readable
+    
+    func ts(prefix: (class: String, protocol: String), classes: [Lexicon.Graph.Node.Class.JSON]) -> [String] {
+        
+        guard mixin == nil else {
+            return []
+        }
+        
+        var lines: [String] = []
+        let T = id.idToClassSuffix
+        let (L, I) = prefix
+        
+        if let protonym = protonym {
+            lines += "type \(L)_\(T) = \(L)_\(protonym.idToClassSuffix)"
+            return lines
+        }
+        
+        lines += "class \(L)_\(T) extends \(L) implements \(I)_\(T) {"
+                
+        let supertype = supertype?
+            .replacingOccurrences(of: "_", with: "__")
+            .replacingOccurrences(of: ".", with: "_")
+            .replacingOccurrences(of: "__&__", with: ", I_")
+        
+        if hasNoProperties {
+            if supertype != nil {
+                let superChildren = classes.filter {$0.id == supertype}.first?.children
+
+                for child in superChildren ?? [] {
+                    lines += "  \(child)!: \(L)_\(supertype!)_\(child);"
+                }
+                lines += "}"
+
+                lines += "type \(I)_\(T) = I_\(supertype!);"
+            } else {
+                lines += "}"
+                lines += "type \(I)_\(T) = I;"
+            }
+        }
+        
+        guard hasProperties else {
+            return lines
+        }
+        
+        // implements
+        
+        for t in type ?? [] {
+            print(t)
+            let subClass = classes.filter{$0.id == t}.first
+            for child in subClass?.children ?? [] {
+                let id = "L.\(t).\(child)"
+                lines += "  \(child)!: \(id.idToClassSuffix);"
+            }
+            if let keys = subClass?.synonyms?.keys {
+                for synonym in keys {
+                    let id = "L.\(t).\(synonym)"
+                    lines += "  \(synonym)!: \(id.idToClassSuffix);"
+                }
+            }
+            
+        }
+        
+        
+        // extends
+        for child in children ?? [] {
+            let id = "\(id).\(child)"
+            lines += "  \(child) = new \(L)_\(id.idToClassSuffix)(`${this.identifier}.\(child)`);"
+        }
+        
+        for (synonym, protonym) in (synonyms?.sortedByLocalizedStandard(by: \.key) ?? []) {
+            lines += "  \(synonym) = this.\(protonym);"
+        }
+        lines += "}"
+        
+        lines += "interface \(I)_\(T) extends \(I)\(supertype.map{ "_\($0)" } ?? "") {"
+        
+        for child in children ?? [] {
+            let id = "\(id).\(child)"
+            lines += "  \(child): \(L)_\(id.idToClassSuffix);"
+        }
+        lines += "}"
+        return lines
+    }
+    
+}
+
+private extension String {
+    
+    var idToClassSuffix: String {
+        replacingOccurrences(of: "_", with: "__")
+            .replacingOccurrences(of: ".", with: "_")
+            .replacingOccurrences(of: "_&_", with: "_")
+    }
+}

--- a/Sources/TypeScriptStandAlone/Generator.swift
+++ b/Sources/TypeScriptStandAlone/Generator.swift
@@ -27,22 +27,22 @@ private extension Lexicon.Graph.JSON {
 // I
 interface I extends TypeLocalized, SourceCodeIdentifiable { }
 interface TypeLocalized {
-	localized: string;
+  localized: string;
 }
 interface SourceCodeIdentifiable {
-	__: string;
-	debugDescription: string;
+  __: string;
+  debugDescription: string;
 }
 // L
 class L implements I {
-	localized: string;
-	__: string;
-	get debugDescription() { return this.__ }
+  localized: string;
+  __: string;
+  get debugDescription() { return this.__ }
 
-	constructor(id: string, localized = "") {
-		this.localized = localized;
-		this.__ = id;
-	}
+  constructor(id: string, localized = "") {
+    this.localized = localized;
+    this.__ = id;
+  }
 }
 // MARK: generated types
 \(classes.flatMap{ $0.ts(prefix: ("L", "I"), classes: classes) }.joined(separator: "\n"))

--- a/Sources/TypeScriptStandAlone/Generator.swift
+++ b/Sources/TypeScriptStandAlone/Generator.swift
@@ -92,8 +92,6 @@ private extension Lexicon.Graph.Node.Class.JSON {
             return lines
         }
         
-        // implements
-        
         for t in type ?? [] {
             let subClass = classes.filter{$0.id == t}.first
             for child in subClass?.children ?? [] {
@@ -109,8 +107,6 @@ private extension Lexicon.Graph.Node.Class.JSON {
             
         }
         
-        
-        // extends
         for child in children ?? [] {
             let id = "\(id).\(child)"
             lines += "  \(child) = new \(L)_\(id.idToClassSuffix)(`${this.identifier}.\(child)`);"
@@ -130,7 +126,6 @@ private extension Lexicon.Graph.Node.Class.JSON {
         lines += "}"
         return lines
     }
-    
 }
 
 private extension String {

--- a/Sources/TypeScriptStandAlone/Generator.swift
+++ b/Sources/TypeScriptStandAlone/Generator.swift
@@ -27,15 +27,17 @@ private extension Lexicon.Graph.JSON {
 // I
 interface I extends TypeLocalized, SourceCodeIdentifiable { }
 interface TypeLocalized {
-	localized: string
+	localized: string;
 }
 interface SourceCodeIdentifiable {
-	__: string
+	__: string;
+	debugDescription: string;
 }
 // L
 class L implements I {
 	localized: string;
 	__: string;
+	get debugDescription() { return this.__ }
 
 	constructor(id: string, localized = "") {
 		this.localized = localized;

--- a/Sources/TypeScriptStandAlone/Generator.swift
+++ b/Sources/TypeScriptStandAlone/Generator.swift
@@ -30,16 +30,16 @@ interface TypeLocalized {
 	localized: string
 }
 interface SourceCodeIdentifiable {
-	identifier: string
+	__: string
 }
 // L
 class L implements I {
 	localized: string;
-	identifier: string;
+	__: string;
 
 	constructor(id: string, localized = "") {
 		this.localized = localized;
-		this.identifier = id;
+		this.__ = id;
 	}
 }
 // MARK: generated types
@@ -113,7 +113,7 @@ private extension Lexicon.Graph.Node.Class.JSON {
 		
 		for child in children ?? [] {
 			let id = "\(id).\(child)"
-			lines += "  \(child) = new \(L)_\(id.idToClassSuffix)(`${this.identifier}.\(child)`);"
+			lines += "  \(child) = new \(L)_\(id.idToClassSuffix)(`${this.__}.\(child)`);"
 		}
 		
 		for (synonym, protonym) in (synonyms?.sortedByLocalizedStandard(by: \.key) ?? []) {

--- a/Sources/TypeScriptStandAlone/Generator.swift
+++ b/Sources/TypeScriptStandAlone/Generator.swift
@@ -5,134 +5,137 @@
 import Lexicon
 import UniformTypeIdentifiers
 
+public extension UTType {
+	static var typescript = UTType(importedAs: "com.microsoft.ts")
+}
+
 public enum Generator: CodeGenerator {
-    
-    // TODO: prefixes?
-    
-    public static let utType = UTType.sourceCode
-    
-    public static func generate(_ json: Lexicon.Graph.JSON) throws -> Data {
-        return Data(json.ts().utf8)
-    }
+	
+	// TODO: prefixes?
+	
+	public static let utType = UTType.typescript
+	
+	public static func generate(_ json: Lexicon.Graph.JSON) throws -> Data {
+		return Data(json.ts().utf8)
+	}
 }
 
 private extension Lexicon.Graph.JSON {
-    
-    func ts() -> String {
-        return """
+	
+	func ts() -> String {
+		return """
 // I
 interface I extends TypeLocalized, SourceCodeIdentifiable { }
 interface TypeLocalized {
-    localized: string
+	localized: string
 }
 interface SourceCodeIdentifiable {
-    identifier: string
+	identifier: string
 }
 // L
 class L implements I {
-    localized: string;
-    identifier: string;
+	localized: string;
+	identifier: string;
 
-    constructor(id: string, localized = "") {
-        this.localized = localized;
-        this.identifier = id;
-    }
+	constructor(id: string, localized = "") {
+		this.localized = localized;
+		this.identifier = id;
+	}
 }
 // MARK: generated types
 \(classes.flatMap{ $0.ts(prefix: ("L", "I"), classes: classes) }.joined(separator: "\n"))
 const \(name) = new L_\(name)("\(name)");
 
 """
-    }
+	}
 }
 
 private extension Lexicon.Graph.Node.Class.JSON {
-    
-    // TODO: make this more readable
-    
-    func ts(prefix: (class: String, protocol: String), classes: [Lexicon.Graph.Node.Class.JSON]) -> [String] {
-        
-        guard mixin == nil else {
-            return []
-        }
-        
-        var lines: [String] = []
-        let T = id.idToClassSuffix
-        let (L, I) = prefix
-        
-        if let protonym = protonym {
-            lines += "type \(L)_\(T) = \(L)_\(protonym.idToClassSuffix)"
-            return lines
-        }
-        
-        lines += "class \(L)_\(T) extends \(L) implements \(I)_\(T) {"
-                
-        let supertype = supertype?
-            .replacingOccurrences(of: "_", with: "__")
-            .replacingOccurrences(of: ".", with: "_")
-            .replacingOccurrences(of: "__&__", with: ", I_")
-        
-        if hasNoProperties {
-            if supertype != nil {
-                let superChildren = classes.filter {$0.id == supertype}.first?.children
+	
+	// TODO: make this more readable
+	
+	func ts(prefix: (class: String, protocol: String), classes: [Lexicon.Graph.Node.Class.JSON]) -> [String] {
+		
+		guard mixin == nil else {
+			return []
+		}
+		
+		var lines: [String] = []
+		let T = id.idToClassSuffix
+		let (L, I) = prefix
+		
+		if let protonym = protonym {
+			lines += "type \(L)_\(T) = \(L)_\(protonym.idToClassSuffix)"
+			return lines
+		}
+		
+		lines += "class \(L)_\(T) extends \(L) implements \(I)_\(T) {"
+				
+		let supertype = supertype?
+			.replacingOccurrences(of: "_", with: "__")
+			.replacingOccurrences(of: ".", with: "_")
+			.replacingOccurrences(of: "__&__", with: ", I_")
+		
+		if hasNoProperties {
+			if supertype != nil {
+				let superChildren = classes.filter {$0.id == supertype}.first?.children
 
-                for child in superChildren ?? [] {
-                    lines += "  \(child)!: \(L)_\(supertype!)_\(child);"
-                }
-                lines += "}"
+				for child in superChildren ?? [] {
+					lines += "  \(child)!: \(L)_\(supertype!)_\(child);"
+				}
+				lines += "}"
 
-                lines += "type \(I)_\(T) = I_\(supertype!);"
-            } else {
-                lines += "}"
-                lines += "type \(I)_\(T) = I;"
-            }
-        }
-        
-        guard hasProperties else {
-            return lines
-        }
-        
-        for t in type ?? [] {
-            let subClass = classes.filter{$0.id == t}.first
-            for child in subClass?.children ?? [] {
-                let id = "L.\(t).\(child)"
-                lines += "  \(child)!: \(id.idToClassSuffix);"
-            }
-            if let keys = subClass?.synonyms?.keys {
-                for synonym in keys {
-                    let id = "L.\(t).\(synonym)"
-                    lines += "  \(synonym)!: \(id.idToClassSuffix);"
-                }
-            }
-            
-        }
-        
-        for child in children ?? [] {
-            let id = "\(id).\(child)"
-            lines += "  \(child) = new \(L)_\(id.idToClassSuffix)(`${this.identifier}.\(child)`);"
-        }
-        
-        for (synonym, protonym) in (synonyms?.sortedByLocalizedStandard(by: \.key) ?? []) {
-            lines += "  \(synonym) = this.\(protonym);"
-        }
-        lines += "}"
-        
-        lines += "interface \(I)_\(T) extends \(I)\(supertype.map{ "_\($0)" } ?? "") {"
-        
-        for child in children ?? [] {
-            let id = "\(id).\(child)"
-            lines += "  \(child): \(L)_\(id.idToClassSuffix);"
-        }
-        lines += "}"
-        return lines
-    }
+				lines += "type \(I)_\(T) = I_\(supertype!);"
+			} else {
+				lines += "}"
+				lines += "type \(I)_\(T) = I;"
+			}
+		}
+		
+		guard hasProperties else {
+			return lines
+		}
+		
+		for t in type ?? [] {
+			let subClass = classes.filter{$0.id == t}.first
+			for child in subClass?.children ?? [] {
+				let id = "L.\(t).\(child)"
+				lines += "  \(child)!: \(id.idToClassSuffix);"
+			}
+			if let keys = subClass?.synonyms?.keys {
+				for synonym in keys {
+					let id = "L.\(t).\(synonym)"
+					lines += "  \(synonym)!: \(id.idToClassSuffix);"
+				}
+			}
+			
+		}
+		
+		for child in children ?? [] {
+			let id = "\(id).\(child)"
+			lines += "  \(child) = new \(L)_\(id.idToClassSuffix)(`${this.identifier}.\(child)`);"
+		}
+		
+		for (synonym, protonym) in (synonyms?.sortedByLocalizedStandard(by: \.key) ?? []) {
+			lines += "  \(synonym) = this.\(protonym);"
+		}
+		lines += "}"
+		
+		lines += "interface \(I)_\(T) extends \(I)\(supertype.map{ "_\($0)" } ?? "") {"
+		
+		for child in children ?? [] {
+			let id = "\(id).\(child)"
+			lines += "  \(child): \(L)_\(id.idToClassSuffix);"
+		}
+		lines += "}"
+		return lines
+	}
 }
 
 private extension String {
-    
-    var idToClassSuffix: String {
-        replacingOccurrences(of: "_", with: "__")
-            .replacingOccurrences(of: ".", with: "_")
-            .replacingOccurrences(of: "_&_", with: "_")
-    }
+	var idToClassSuffix: String {
+		replacingOccurrences(of: "_", with: "__")
+			.replacingOccurrences(of: ".", with: "_")
+			.replacingOccurrences(of: "_&_", with: "_")
+	}
 }

--- a/Tests/TypeScriptStandAloneTests/Resources/test.taskpaper
+++ b/Tests/TypeScriptStandAloneTests/Resources/test.taskpaper
@@ -1,0 +1,17 @@
+test:
+	one:
+	+ test.type.odd
+		more:
+			time:
+			+ test
+	two:
+	+ test.type.even
+		timing:
+	type:
+		even:
+			bad:
+			= no.good
+			no:
+				good:
+		odd:
+			good:

--- a/Tests/TypeScriptStandAloneTests/Resources/test.ts
+++ b/Tests/TypeScriptStandAloneTests/Resources/test.ts
@@ -4,23 +4,23 @@ interface TypeLocalized {
 	localized: string
 }
 interface SourceCodeIdentifiable {
-	identifier: string
+	__: string
 }
 // L
 class L implements I {
 	localized: string;
-	identifier: string;
+	__: string;
 
 	constructor(id: string, localized = "") {
 		this.localized = localized;
-		this.identifier = id;
+		this.__ = id;
 	}
 }
 // MARK: generated types
 class L_test extends L implements I_test {
-  one = new L_test_one(`${this.identifier}.one`);
-  two = new L_test_two(`${this.identifier}.two`);
-  type = new L_test_type(`${this.identifier}.type`);
+  one = new L_test_one(`${this.__}.one`);
+  two = new L_test_two(`${this.__}.two`);
+  type = new L_test_type(`${this.__}.type`);
 }
 interface I_test extends I {
   one: L_test_one;
@@ -29,13 +29,13 @@ interface I_test extends I {
 }
 class L_test_one extends L implements I_test_one {
   good!: L_test_type_odd_good;
-  more = new L_test_one_more(`${this.identifier}.more`);
+  more = new L_test_one_more(`${this.__}.more`);
 }
 interface I_test_one extends I_test_type_odd {
   more: L_test_one_more;
 }
 class L_test_one_more extends L implements I_test_one_more {
-  time = new L_test_one_more_time(`${this.identifier}.time`);
+  time = new L_test_one_more_time(`${this.__}.time`);
 }
 interface I_test_one_more extends I {
   time: L_test_one_more_time;
@@ -49,7 +49,7 @@ type I_test_one_more_time = I_test;
 class L_test_two extends L implements I_test_two {
   no!: L_test_type_even_no;
   bad!: L_test_type_even_bad;
-  timing = new L_test_two_timing(`${this.identifier}.timing`);
+  timing = new L_test_two_timing(`${this.__}.timing`);
 }
 interface I_test_two extends I_test_type_even {
   timing: L_test_two_timing;
@@ -58,15 +58,15 @@ class L_test_two_timing extends L implements I_test_two_timing {
 }
 type I_test_two_timing = I;
 class L_test_type extends L implements I_test_type {
-  even = new L_test_type_even(`${this.identifier}.even`);
-  odd = new L_test_type_odd(`${this.identifier}.odd`);
+  even = new L_test_type_even(`${this.__}.even`);
+  odd = new L_test_type_odd(`${this.__}.odd`);
 }
 interface I_test_type extends I {
   even: L_test_type_even;
   odd: L_test_type_odd;
 }
 class L_test_type_even extends L implements I_test_type_even {
-  no = new L_test_type_even_no(`${this.identifier}.no`);
+  no = new L_test_type_even_no(`${this.__}.no`);
   bad = this.no.good;
 }
 interface I_test_type_even extends I {
@@ -74,7 +74,7 @@ interface I_test_type_even extends I {
 }
 type L_test_type_even_bad = L_test_type_even_no_good
 class L_test_type_even_no extends L implements I_test_type_even_no {
-  good = new L_test_type_even_no_good(`${this.identifier}.good`);
+  good = new L_test_type_even_no_good(`${this.__}.good`);
 }
 interface I_test_type_even_no extends I {
   good: L_test_type_even_no_good;
@@ -83,7 +83,7 @@ class L_test_type_even_no_good extends L implements I_test_type_even_no_good {
 }
 type I_test_type_even_no_good = I;
 class L_test_type_odd extends L implements I_test_type_odd {
-  good = new L_test_type_odd_good(`${this.identifier}.good`);
+  good = new L_test_type_odd_good(`${this.__}.good`);
 }
 interface I_test_type_odd extends I {
   good: L_test_type_odd_good;

--- a/Tests/TypeScriptStandAloneTests/Resources/test.ts
+++ b/Tests/TypeScriptStandAloneTests/Resources/test.ts
@@ -1,20 +1,20 @@
 // I
 interface I extends TypeLocalized, SourceCodeIdentifiable { }
 interface TypeLocalized {
-    localized: string
+	localized: string
 }
 interface SourceCodeIdentifiable {
-    identifier: string
+	identifier: string
 }
 // L
 class L implements I {
-    localized: string;
-    identifier: string;
+	localized: string;
+	identifier: string;
 
-    constructor(id: string, localized = "") {
-        this.localized = localized;
-        this.identifier = id;
-    }
+	constructor(id: string, localized = "") {
+		this.localized = localized;
+		this.identifier = id;
+	}
 }
 // MARK: generated types
 class L_test extends L implements I_test {

--- a/Tests/TypeScriptStandAloneTests/Resources/test.ts
+++ b/Tests/TypeScriptStandAloneTests/Resources/test.ts
@@ -1,22 +1,22 @@
 // I
 interface I extends TypeLocalized, SourceCodeIdentifiable { }
 interface TypeLocalized {
-	localized: string;
+  localized: string;
 }
 interface SourceCodeIdentifiable {
-	__: string;
-	debugDescription: string;
+  __: string;
+  debugDescription: string;
 }
 // L
 class L implements I {
-	localized: string;
-	__: string;
-	get debugDescription() { return this.__ }
+  localized: string;
+  __: string;
+  get debugDescription() { return this.__ }
 
-	constructor(id: string, localized = "") {
-		this.localized = localized;
-		this.__ = id;
-	}
+  constructor(id: string, localized = "") {
+    this.localized = localized;
+    this.__ = id;
+  }
 }
 // MARK: generated types
 class L_test extends L implements I_test {

--- a/Tests/TypeScriptStandAloneTests/Resources/test.ts
+++ b/Tests/TypeScriptStandAloneTests/Resources/test.ts
@@ -1,23 +1,16 @@
-// I
-interface I extends TypeLocalized, SourceCodeIdentifiable { }
-interface TypeLocalized {
-  localized: string;
-}
-interface SourceCodeIdentifiable {
-  __: string;
-  debugDescription: string;
-}
+interface I { }
+
 // L
 class L implements I {
-  localized: string;
-  __: string;
-  get debugDescription() { return this.__ }
-
-  constructor(id: string, localized = "") {
-    this.localized = localized;
-    this.__ = id;
-  }
+	protected id: string;
+	constructor(id: string) {
+		this.id = id;
+	}
+	get ['__']() {
+		return this.id;
+	}
 }
+
 // MARK: generated types
 class L_test extends L implements I_test {
   one = new L_test_one(`${this.__}.one`);
@@ -25,22 +18,22 @@ class L_test extends L implements I_test {
   type = new L_test_type(`${this.__}.type`);
 }
 interface I_test extends I {
-  one: L_test_one;
-  two: L_test_two;
-  type: L_test_type;
+  one: I_test_one;
+  two: I_test_two;
+  type: I_test_type;
 }
 class L_test_one extends L implements I_test_one {
   good!: L_test_type_odd_good;
   more = new L_test_one_more(`${this.__}.more`);
 }
 interface I_test_one extends I_test_type_odd {
-  more: L_test_one_more;
+  more: I_test_one_more;
 }
 class L_test_one_more extends L implements I_test_one_more {
   time = new L_test_one_more_time(`${this.__}.time`);
 }
 interface I_test_one_more extends I {
-  time: L_test_one_more_time;
+  time: I_test_one_more_time;
 }
 class L_test_one_more_time extends L implements I_test_one_more_time {
   one!: L_test_one;
@@ -54,7 +47,7 @@ class L_test_two extends L implements I_test_two {
   timing = new L_test_two_timing(`${this.__}.timing`);
 }
 interface I_test_two extends I_test_type_even {
-  timing: L_test_two_timing;
+  timing: I_test_two_timing;
 }
 class L_test_two_timing extends L implements I_test_two_timing {
 }
@@ -64,22 +57,22 @@ class L_test_type extends L implements I_test_type {
   odd = new L_test_type_odd(`${this.__}.odd`);
 }
 interface I_test_type extends I {
-  even: L_test_type_even;
-  odd: L_test_type_odd;
+  even: I_test_type_even;
+  odd: I_test_type_odd;
 }
 class L_test_type_even extends L implements I_test_type_even {
   no = new L_test_type_even_no(`${this.__}.no`);
   bad = this.no.good;
 }
 interface I_test_type_even extends I {
-  no: L_test_type_even_no;
+  no: I_test_type_even_no;
 }
 type L_test_type_even_bad = L_test_type_even_no_good
 class L_test_type_even_no extends L implements I_test_type_even_no {
   good = new L_test_type_even_no_good(`${this.__}.good`);
 }
 interface I_test_type_even_no extends I {
-  good: L_test_type_even_no_good;
+  good: I_test_type_even_no_good;
 }
 class L_test_type_even_no_good extends L implements I_test_type_even_no_good {
 }
@@ -88,7 +81,7 @@ class L_test_type_odd extends L implements I_test_type_odd {
   good = new L_test_type_odd_good(`${this.__}.good`);
 }
 interface I_test_type_odd extends I {
-  good: L_test_type_odd_good;
+  good: I_test_type_odd_good;
 }
 class L_test_type_odd_good extends L implements I_test_type_odd_good {
 }

--- a/Tests/TypeScriptStandAloneTests/Resources/test.ts
+++ b/Tests/TypeScriptStandAloneTests/Resources/test.ts
@@ -1,0 +1,94 @@
+// I
+interface I extends TypeLocalized, SourceCodeIdentifiable { }
+interface TypeLocalized {
+    localized: string
+}
+interface SourceCodeIdentifiable {
+    identifier: string
+}
+// L
+class L implements I {
+    localized: string;
+    identifier: string;
+
+    constructor(id: string, localized = "") {
+        this.localized = localized;
+        this.identifier = id;
+    }
+}
+// MARK: generated types
+class L_test extends L implements I_test {
+  one = new L_test_one(`${this.identifier}.one`);
+  two = new L_test_two(`${this.identifier}.two`);
+  type = new L_test_type(`${this.identifier}.type`);
+}
+interface I_test extends I {
+  one: L_test_one;
+  two: L_test_two;
+  type: L_test_type;
+}
+class L_test_one extends L implements I_test_one {
+  good!: L_test_type_odd_good;
+  more = new L_test_one_more(`${this.identifier}.more`);
+}
+interface I_test_one extends I_test_type_odd {
+  more: L_test_one_more;
+}
+class L_test_one_more extends L implements I_test_one_more {
+  time = new L_test_one_more_time(`${this.identifier}.time`);
+}
+interface I_test_one_more extends I {
+  time: L_test_one_more_time;
+}
+class L_test_one_more_time extends L implements I_test_one_more_time {
+  one!: L_test_one;
+  two!: L_test_two;
+  type!: L_test_type;
+}
+type I_test_one_more_time = I_test;
+class L_test_two extends L implements I_test_two {
+  no!: L_test_type_even_no;
+  bad!: L_test_type_even_bad;
+  timing = new L_test_two_timing(`${this.identifier}.timing`);
+}
+interface I_test_two extends I_test_type_even {
+  timing: L_test_two_timing;
+}
+class L_test_two_timing extends L implements I_test_two_timing {
+}
+type I_test_two_timing = I;
+class L_test_type extends L implements I_test_type {
+  even = new L_test_type_even(`${this.identifier}.even`);
+  odd = new L_test_type_odd(`${this.identifier}.odd`);
+}
+interface I_test_type extends I {
+  even: L_test_type_even;
+  odd: L_test_type_odd;
+}
+class L_test_type_even extends L implements I_test_type_even {
+  no = new L_test_type_even_no(`${this.identifier}.no`);
+  bad = this.no.good;
+}
+interface I_test_type_even extends I {
+  no: L_test_type_even_no;
+}
+type L_test_type_even_bad = L_test_type_even_no_good
+class L_test_type_even_no extends L implements I_test_type_even_no {
+  good = new L_test_type_even_no_good(`${this.identifier}.good`);
+}
+interface I_test_type_even_no extends I {
+  good: L_test_type_even_no_good;
+}
+class L_test_type_even_no_good extends L implements I_test_type_even_no_good {
+}
+type I_test_type_even_no_good = I;
+class L_test_type_odd extends L implements I_test_type_odd {
+  good = new L_test_type_odd_good(`${this.identifier}.good`);
+}
+interface I_test_type_odd extends I {
+  good: L_test_type_odd_good;
+}
+class L_test_type_odd_good extends L implements I_test_type_odd_good {
+}
+type I_test_type_odd_good = I;
+const test = new L_test("test");

--- a/Tests/TypeScriptStandAloneTests/Resources/test.ts
+++ b/Tests/TypeScriptStandAloneTests/Resources/test.ts
@@ -1,15 +1,17 @@
 // I
 interface I extends TypeLocalized, SourceCodeIdentifiable { }
 interface TypeLocalized {
-	localized: string
+	localized: string;
 }
 interface SourceCodeIdentifiable {
-	__: string
+	__: string;
+	debugDescription: string;
 }
 // L
 class L implements I {
 	localized: string;
 	__: string;
+	get debugDescription() { return this.__ }
 
 	constructor(id: string, localized = "") {
 		this.localized = localized;

--- a/Tests/TypeScriptStandAloneTests/TypeScriptStandAlone™.swift
+++ b/Tests/TypeScriptStandAloneTests/TypeScriptStandAlone™.swift
@@ -1,0 +1,28 @@
+@_exported import Hope
+@_exported import Combine
+@_exported import Lexicon
+@_exported import TypeScriptStandAlone
+
+final class TypeScriptLexicon™: Hopes {
+	
+	func test_generator() async throws {
+		
+		var json = try await "test".taskpaper().lexicon().json()
+		json.date = Date(timeIntervalSinceReferenceDate: 0)
+		
+		let code = try Generator.generate(json).string()
+        		
+		try hope(code) == "test.ts".file().string()
+	}
+	
+	func test_code() throws {
+		/**
+		 @Test
+		 fun generator(){
+			assert(test.one.more.time.one.more.time.identifier == "test.one.more.time.one.more.time")
+			assert(test.two.bad == test.two.no.good)
+			assert(test.two.bad.identifier == "test.two.no.good")
+		 }
+		 */
+	}
+}

--- a/Tests/TypeScriptStandAloneTests/util.swift
+++ b/Tests/TypeScriptStandAloneTests/util.swift
@@ -1,0 +1,30 @@
+//
+// github.com/screensailor 2022
+//
+
+import Foundation
+
+extension String {
+	
+	func taskpaper() throws -> String {
+		try "\(self).taskpaper".file().string()
+	}
+	
+	func file() throws -> Data {
+		guard let url = Bundle.module.url(forResource: "Resources/\(self)", withExtension: nil) else {
+			throw "Could not find '\(self)'"
+		}
+		return  try Data(contentsOf: url)
+	}
+	
+	func lexicon() async throws -> Lexicon {
+		try await Lexicon.from(TaskPaper(self).decode())
+	}
+}
+
+extension Data {
+	
+	func string(encoding: String.Encoding = .utf8) throws -> String {
+		try String(data: self, encoding: encoding).try()
+	}
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6069506/170724446-da68c636-a7ea-4b49-8940-ba31807fed6f.png)

Typescript generator 

Bit of extra fiddling compared to Swift and Kotlin.

Looking at the `L_test_one` class in `TS` it needs to explicitly state the `good` property. 
In Swift/Kotlin it doesn't. Guess this is a difference in the protocol(interface) inheritance??

```
class L_test_one extends L implements I_test_one {
  good!: L_test_type_odd_good;
  more = new L_test_one_more(`${this.identifier}.more`);
}
interface I_test_one extends I_test_type_odd {
  more: L_test_one_more;
}
```


```
public final class L_test_one: L, I_test_one {
	public override class var localized: String { NSLocalizedString("test.one", comment: "") }
}
public protocol I_test_one: I_test_type_odd {}
public extension I_test_one {
	var `more`: L_test_one_more { .init("\(__).more") }
}
```