### PR TITLE
Resolve an issue where inherited nodes past depth 1 correctly inherit own types

### DIFF
--- a/Sources/Lexicon/Lemma.swift
+++ b/Sources/Lexicon/Lemma.swift
@@ -362,9 +362,10 @@ extension Lemma {
 			for id in node.type {
 				o[id] = lexicon.dictionary[id].map(Unowned.init)
 			}
-		} else {
-			for id in (parent?.node.type).or([]) {
-				guard let node = lexicon.dictionary[id]?.children[name] else { continue }
+		} else if let parent = lineage.first(where: \.isGraphNode) {
+			let descendant = id.dotPath(after: parent.id).split(separator: ".").map(Name.init)
+			for id in parent.node.type {
+				guard let node = lexicon.dictionary[id]?[descendant] else { continue }
 				o[node.id] = Unowned(node)
 			}
 		}

--- a/Sources/lexicon-generate/CodeGenerator.swift
+++ b/Sources/lexicon-generate/CodeGenerator.swift
@@ -51,7 +51,7 @@ struct CodeGeneratorCommand: AsyncParsableCommand {
 			TaskPaper(Data(contentsOf: input)).decode()
 		)
 		let json = await lexicon.json()
-		let code = try type.map { command in
+		let code = try type.map { command -> (URL, Data) in
 			guard let generator = Lexicon.Graph.JSON.generators.find(command) else {
 				fatalError("Unable to find a generator for \(command)")
 			}

--- a/Tests/LexiconTests/Lemma™.swift
+++ b/Tests/LexiconTests/Lemma™.swift
@@ -25,4 +25,46 @@ final class Lemma™: Hopes {
 		hope.false(Lemma.isValid(character: "_", appendingTo: "not_another_"))
 		hope.false(Lemma.isValid(character: "_", appendingTo: "")) // TODO: consider allowing this!
 	}
+
+	func test_inherited_node_own_type() async throws {
+
+		let root = try await Lexicon.from(
+			TaskPaper(inherited_node_own_type).decode()
+		).root
+
+		let userId = try await root["user", "id"].hopefully()
+		let collectionId = try await root["db", "collection", "id"].hopefully()
+
+		let isCollectionId = await userId.is(collectionId)
+
+		hope(isCollectionId) == true
+	}
+
+	func test_inherited_node_own_type_nested() async throws {
+
+		let root = try await Lexicon.from(
+			TaskPaper(inherited_node_own_type).decode()
+		).root
+
+		let userbc = try await root["user", "b", "c"].hopefully()
+		let abc = try await root["a", "b", "c"].hopefully()
+
+		let matches = await userbc.is(abc)
+
+		hope(matches) == true
+	}
 }
+
+private let inherited_node_own_type = """
+root:
+	a:
+		b:
+			c:
+	db:
+		collection:
+			id:
+	user:
+	+ root.db.collection
+	+ root.a
+"""
+

--- a/Tests/LexiconTests/Lemma™.swift
+++ b/Tests/LexiconTests/Lemma™.swift
@@ -46,20 +46,35 @@ final class Lemma™: Hopes {
 			TaskPaper(inherited_node_own_type).decode()
 		).root
 
-		let userbc = try await root["user", "b", "c"].hopefully()
-		let abc = try await root["a", "b", "c"].hopefully()
+		do {
+			let a = try await root["user", "b", "c"].hopefully()
+			let b = try await root["a", "b", "c"].hopefully()
+			let matches = await a.is(b)
+			hope(matches) == true
+		}
 
-		let matches = await userbc.is(abc)
-
-		hope(matches) == true
+		do {
+			let a = try await root["a", "two", "two", "two", "three"].hopefully()
+			let b = try await root["one", "two", "three"].hopefully()
+			let matches = await a.is(b)
+			hope(matches) == true
+		}
 	}
 }
 
 private let inherited_node_own_type = """
 root:
 	a:
+	+ root.one
 		b:
+		+ root.two
 			c:
+			+ root.three
+	one:
+		two:
+		+ root.a
+			three:
+			+ root.b
 	db:
 		collection:
 			id:

--- a/Tests/LexiconTests/Lexicon™.swift
+++ b/Tests/LexiconTests/Lexicon™.swift
@@ -28,20 +28,6 @@ final class Lexicon™: Hopes {
 		
 		// TODO: ...
 	}
-
-	func test_inherited_node_own_type() async throws {
-
-		let root = try await Lexicon.from(
-			TaskPaper(inherited_node_own_type).decode()
-		).root
-
-		let userId = try await root["user", "id"].hopefully()
-		let collectionId = try await root["db", "collection", "id"].hopefully()
-
-		let isCollectionId = await userId.is(collectionId)
-
-		hope(isCollectionId) == true
-	}
 }
 
 private let taskpaper = """
@@ -90,13 +76,4 @@ root:
 				+ root.type.ux.journey
 					json:
 					taskpaper:
-"""
-
-private let inherited_node_own_type = """
-root:
-	db:
-		collection:
-			id:
-	user:
-	+ root.db.collection
 """


### PR DESCRIPTION
The previous fix here was only working up to a single inherited depth, this ensures we traverse back until we find a graph node to inherit the types all from, this will work recursively as demonstrated in the Lemma™